### PR TITLE
Update Node.js versions in workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 10.x
           - 12.x
           - 14.x
+          - 16.x
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Node.js v16 is released and v10.* is outdated.
