### PR TITLE
Bump eslint versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1599,9 +1599,9 @@
       "dev": true
     },
     "eslint-plugin-jest": {
-      "version": "26.9.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-26.9.0.tgz",
-      "integrity": "sha512-TWJxWGp1J628gxh2KhaH1H1paEdgE2J61BBF1I59c6xWeL5+D1BzMxGDN/nXAfX+aSkR5u80K+XhskK6Gwq9ng==",
+      "version": "27.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.1.tgz",
+      "integrity": "sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==",
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.10.0"

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "test": "jest --verbose"
   },
   "devDependencies": {
-    "@types/eslint": "^8.4.0",
+    "@types/eslint": "^8.37.0",
     "@types/jest": "^28.1.0",
     "@types/prettier": "^2.6.0",
-    "eslint": "^8.20.0",
-    "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-jest": "^26.6.0",
+    "eslint": "^8.37.0",
+    "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-jest": "^27.2.0",
     "eslint-plugin-prettier": "^4.2.0",
     "jest": "^28.1.0",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
- Bumps [eslint](https://github.com/eslint/eslint) from `8.4.0` to `8.37.0`.
- Bumps [@types/eslint](https://github.com/DefinitelyTyped/DefinitelyTyped) from `8.4.0` to `8.37.0`.
- Bumps [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) from `8.5.0` to `8.8.0`.
- Bumps [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest) from `26.6.0` to `27.2.0`.