### PR TITLE
Remove node-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,9 @@
     "@types/eslint": "^8.56.0",
     "@types/prettier": "^3.0.0",
     "@types/tap": "^15.0.0",
+    "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.0",
-    "eslint": "^8.56.0",
-    "node-fetch": "^3.3.1",
     "prettier": "^3.1.0",
     "tap": "^18.6.0"
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,4 @@
 import * as fs from "node:fs/promises";
-import fetch from "node-fetch";
 import prettier from "prettier";
 
 const GOOGLE_SUPPORTED_DOMAINS_URL = "https://www.google.com/supported_domains";


### PR DESCRIPTION
Node.js 18 (LTS) supports **Fetch API**. We don't need **node-fetch** now.
